### PR TITLE
Improve idle army #70

### DIFF
--- a/actions/army_control.py
+++ b/actions/army_control.py
@@ -76,11 +76,14 @@ class ArmyControl(Micro):
 
     def move_to_rallying_point(self, unit):
         """Set the point where the units should gather"""
-        self.ai.actions.append(
-            unit.move(
-                self.ai.townhalls.closest_to(self.ai._game_info.map_center).position.towards(self.ai._game_info.map_center, 10)
-            )
+        rally_point = (
+            self.ai.townhalls
+            .closest_to(self.ai._game_info.map_center)
+            .position
+            .towards(self.ai._game_info.map_center, 10)
         )
+        if unit.distance_to(rally_point) > 5:
+            self.ai.actions.append(unit.move(rally_point))
 
     def has_retreated(self, unit):
         """Identify if the unit has retreated"""


### PR DESCRIPTION
only units outside of the idle area are send to move to the rally point.

it could be improved and the area could be increased but for now it should give better performance

fix for #70 