### PR TITLE
Simplifications on \train

### DIFF
--- a/actions/train/overlord.py
+++ b/actions/train/overlord.py
@@ -11,7 +11,9 @@ class TrainOverlord:
     async def should_handle(self, iteration):
         """We still get supply blocked sometimes, can be improved a lot still"""
         local_controller = self.ai
-        if local_controller.supply_cap <= 200 and local_controller.supply_left < (7 + local_controller.supply_used // 7):
+        if local_controller.supply_cap <= 200 and local_controller.supply_left < (
+            7 + local_controller.supply_used // 7
+        ):
             overlords_in_queue = local_controller.already_pending(OVERLORD)
             if local_controller.can_train(OVERLORD):
                 base_amount = len(local_controller.townhalls)

--- a/actions/train/worker.py
+++ b/actions/train/worker.py
@@ -32,10 +32,16 @@ class TrainWorker:
             )
             return (
                 workers_total + drones_in_queue < optimal_workers
-                and np.sum(np.array(
-                    [len(local_controller.zerglings), len(local_controller.hydras), len(local_controller.ultralisks)]
+                and np.sum(
+                    np.array(
+                        [
+                            len(local_controller.zerglings),
+                            len(local_controller.hydras),
+                            len(local_controller.ultralisks),
+                        ]
+                    )
+                    * np.array([1, 2, 3])
                 )
-                * np.array([1, 2, 3]))
                 > 15
             )
         return False

--- a/actions/train/zergling.py
+++ b/actions/train/zergling.py
@@ -19,13 +19,13 @@ class TrainZergling:
             return False
         if not local_controller.can_train(ZERGLING):
             return False
-        if local_controller.time < 1380:
-            if local_controller.caverns.ready and len(local_controller.ultralisks) * 8.5 <= len(zerglings):
-                return False
-            if local_controller.hydradens.ready and len(local_controller.hydras) * 3 <= len(zerglings):
-                return False
+        zergling_quantity = len(zerglings)
+        if local_controller.caverns.ready and len(local_controller.ultralisks) * 8.5 <= zergling_quantity:
+            return False
+        if local_controller.hydradens.ready and len(local_controller.hydras) * 3 <= zergling_quantity:
+            return False
         if local_controller.floating_buildings_bm:
-            if (local_controller.supply_used > 150) or (len(local_controller.mutalisks) * 10 <= len(zerglings)):
+            if (local_controller.supply_used > 150) or (len(local_controller.mutalisks) * 10 <= zergling_quantity):
                 return False
         return True
 


### PR DESCRIPTION
There are 2 functional changes on this pr:
Removed the 1380 seconds time limit for checking hydra-ultras-zerglings ratio from testing (it actually weakens the bot a little), also the limit for overlord queued now is at 3(instead of 2) all other changes are not functional 